### PR TITLE
Support for null-terminated string messages

### DIFF
--- a/NamedPipeWrapper/IO/PipeStreamReader.cs
+++ b/NamedPipeWrapper/IO/PipeStreamReader.cs
@@ -4,6 +4,7 @@ using System.IO.Pipes;
 using System.Net;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 
 namespace NamedPipeWrapper.IO
 {
@@ -80,8 +81,22 @@ namespace NamedPipeWrapper.IO
         /// <exception cref="SerializationException">An object in the graph of type parameter <typeparamref name="T"/> is not marked as serializable.</exception>
         public T ReadObject()
         {
+            if (typeof(T) == typeof(string))
+            {
+                return (T) ReadString();
+            }
             var len = ReadLength();
             return len == 0 ? default(T) : ReadObject(len);
+        }
+
+        private object ReadString()
+        {
+            const int bufferSize = 1024;
+            var data = new byte[bufferSize];
+            BaseStream.Read(data, 0, bufferSize);
+            var message = Encoding.UTF8.GetString(data).TrimEnd('\0');
+            
+            return message.Length > 0 ? message : null;
         }
     }
 }

--- a/NamedPipeWrapper/IO/PipeStreamWriter.cs
+++ b/NamedPipeWrapper/IO/PipeStreamWriter.cs
@@ -68,18 +68,19 @@ namespace NamedPipeWrapper.IO
         /// <exception cref="SerializationException">An object in the graph of type parameter <typeparamref name="T"/> is not marked as serializable.</exception>
         public void WriteObject(T obj)
         {
+            byte[] data;
             if (typeof(T) == typeof(string))
             {
-                WriteObject(Encoding.UTF8.GetBytes(obj.ToString()));
-                Flush();
+                data = Encoding.UTF8.GetBytes(obj.ToString());
+
             }
             else
             {
-                var data = Serialize(obj);
+                data = Serialize(obj);
                 WriteLength(data.Length);
-                WriteObject(data);
-                Flush();
             }
+            WriteObject(data);
+            Flush();
         }
 
         /// <summary>

--- a/NamedPipeWrapper/IO/PipeStreamWriter.cs
+++ b/NamedPipeWrapper/IO/PipeStreamWriter.cs
@@ -4,6 +4,7 @@ using System.IO.Pipes;
 using System.Net;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 
 namespace NamedPipeWrapper.IO
 {
@@ -67,10 +68,18 @@ namespace NamedPipeWrapper.IO
         /// <exception cref="SerializationException">An object in the graph of type parameter <typeparamref name="T"/> is not marked as serializable.</exception>
         public void WriteObject(T obj)
         {
-            var data = Serialize(obj);
-            WriteLength(data.Length);
-            WriteObject(data);
-            Flush();
+            if (typeof(T) == typeof(string))
+            {
+                WriteObject(Encoding.UTF8.GetBytes(obj.ToString()));
+                Flush();
+            }
+            else
+            {
+                var data = Serialize(obj);
+                WriteLength(data.Length);
+                WriteObject(data);
+                Flush();
+            }
         }
 
         /// <summary>

--- a/NamedPipeWrapper/IO/PipeStreamWriter.cs
+++ b/NamedPipeWrapper/IO/PipeStreamWriter.cs
@@ -72,7 +72,6 @@ namespace NamedPipeWrapper.IO
             if (typeof(T) == typeof(string))
             {
                 data = Encoding.UTF8.GetBytes(obj.ToString());
-
             }
             else
             {

--- a/NamedPipeWrapper/NamedPipeServer.cs
+++ b/NamedPipeWrapper/NamedPipeServer.cs
@@ -259,15 +259,17 @@ namespace NamedPipeWrapper
 
 			try
 			{
+				dataPipe = CreatePipe(connectionPipeName);
+
 				// Send the client the name of the data pipe to use
 				handshakePipe = CreateAndConnectPipe();
 				var handshakeWrapper = new PipeStreamWrapper<string, string>(handshakePipe);
+
 				handshakeWrapper.WriteObject(connectionPipeName);
 				handshakeWrapper.WaitForPipeDrain();
 				handshakeWrapper.Close();
 
 				// Wait for the client to connect to the data pipe
-				dataPipe = CreatePipe(connectionPipeName);
 				dataPipe.WaitForConnection();
 
 				// Add the client's connection to the list of connections

--- a/NamedPipeWrapper/StringNamedPipeServer.cs
+++ b/NamedPipeWrapper/StringNamedPipeServer.cs
@@ -1,0 +1,16 @@
+﻿using System.IO.Pipes;
+
+namespace NamedPipeWrapper
+{
+    public class StringNamedPipeServer : NamedPipeServer<string>
+    {
+        public StringNamedPipeServer(string pipeName) : base(pipeName)
+        {
+        }
+
+        public StringNamedPipeServer(string pipeName, int bufferSize, PipeSecurity security) : base(pipeName,
+            bufferSize, security)
+        {
+        }
+    }
+}

--- a/UnitTests/StringNamedPipeTests.cs
+++ b/UnitTests/StringNamedPipeTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO.Pipes;
+using System.Threading;
+using FluentAssertions;
+using NamedPipeWrapper;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class StringNamedPipeTests
+    {
+        private const string PipeName = "test-pipe";
+        private const int Timeout = 1000;
+
+        private StringNamedPipeServer _server;
+        private StringNamedPipeClient _client;
+
+        private ConcurrentQueue<string> _serverMessageQueue;
+        private ManualResetEvent _clientMessageReceivedEvent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _serverMessageQueue = new ConcurrentQueue<string>();
+            _clientMessageReceivedEvent = new ManualResetEvent(false);
+
+            _server = new StringNamedPipeServer(PipeName);
+            _client = new StringNamedPipeClient(PipeName);
+
+            _server.ClientMessage += OnClientMessageReceived;
+            _server.Start();
+            _client.Start();
+            _client.WaitForConnection();
+        }
+
+        private void OnClientMessageReceived(NamedPipeConnection<string, string> connection, string message)
+        {
+            _serverMessageQueue.Enqueue(message);
+            _clientMessageReceivedEvent.Set();
+        }
+
+        [Test]
+        public void ReadMessageShouldMatchSentMessage()
+        {
+            var message = Guid.NewGuid().ToString();
+            _client.PushMessage(message);
+
+            _clientMessageReceivedEvent.WaitOne(Timeout);
+
+            string messageReceived;
+            _serverMessageQueue.TryDequeue(out messageReceived);
+            messageReceived.Should().Be(message);
+        }
+    }
+
+    public class StringNamedPipeClient : NamedPipeClient<string>
+    {
+        public StringNamedPipeClient(string pipeName) : base(pipeName)
+        {
+        }
+    }
+
+    public class StringNamedPipeServer : NamedPipeServer<string>
+    {
+        public StringNamedPipeServer(string pipeName) : base(pipeName)
+        {
+        }
+
+        public StringNamedPipeServer(string pipeName, int bufferSize, PipeSecurity security) : base(pipeName,
+            bufferSize, security)
+        {
+        }
+    }
+}

--- a/UnitTests/StringNamedPipeTests.cs
+++ b/UnitTests/StringNamedPipeTests.cs
@@ -58,6 +58,7 @@ namespace UnitTests
             messageReceived.Should().Be(message);
         }
 
+        #region Helpers
         private void StartServer()
         {
             _server = new StringNamedPipeServer(PipeName);
@@ -99,5 +100,6 @@ namespace UnitTests
             _serverMessageQueue.Enqueue(message);
             _serverReceivedMessageEvent.Set();
         }
+        #endregion
     }
 }


### PR DESCRIPTION
This PR adds special handling for string-based named pipes. This is to make it simpler to communicate with a C++ client. 

To simplify the read/write protocol:
* When **writing** to the pipe - instead of sending the object size before sending the object, a null-terminated string is with a max size of 1024 bytes is sent.
* When **reading** from pipe - instead of expecting the object size first, the string is read directly and trimmed. Max size 1024 bytes.