### PR TITLE
Support for message mode

### DIFF
--- a/NamedPipeWrapper/IO/PipeStreamReader.cs
+++ b/NamedPipeWrapper/IO/PipeStreamReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Net;
@@ -94,7 +94,7 @@ namespace NamedPipeWrapper.IO
             const int bufferSize = 1024;
             var data = new byte[bufferSize];
             BaseStream.Read(data, 0, bufferSize);
-            var message = Encoding.UTF8.GetString(data).TrimEnd('\0');
+            var message = Encoding.Unicode.GetString(data).TrimEnd('\0');
             
             return message.Length > 0 ? message : null;
         }

--- a/NamedPipeWrapper/IO/PipeStreamWriter.cs
+++ b/NamedPipeWrapper/IO/PipeStreamWriter.cs
@@ -71,7 +71,7 @@ namespace NamedPipeWrapper.IO
             byte[] data;
             if (typeof(T) == typeof(string))
             {
-                data = Encoding.UTF8.GetBytes(obj.ToString());
+                data = Encoding.Unicode.GetBytes(obj.ToString());
             }
             else
             {

--- a/NamedPipeWrapper/NamedPipeServer.cs
+++ b/NamedPipeWrapper/NamedPipeServer.cs
@@ -420,7 +420,7 @@ namespace NamedPipeWrapper
 			_logger = logger;
 		}
 
-		public void LogDebug(string message)
+		private void LogDebug(string message)
 		{
 			if (_logger != null)
 			{
@@ -428,7 +428,7 @@ namespace NamedPipeWrapper
 			}
 		}
 
-		public void LogError(Exception exception, string message)
+		private void LogError(Exception exception, string message)
 		{
 			if (_logger != null)
 			{

--- a/NamedPipeWrapper/PipeServerFactory.cs
+++ b/NamedPipeWrapper/PipeServerFactory.cs
@@ -1,33 +1,35 @@
-using System.IO.Pipes;
+﻿using System.IO.Pipes;
 
 namespace NamedPipeWrapper
 {
-	static class PipeServerFactory
-	{
-		public static NamedPipeServerStream CreateAndConnectPipe(string pipeName)
-		{
-			var pipe = CreatePipe(pipeName);
-			pipe.WaitForConnection();
+    static class PipeServerFactory
+    {
+        public static NamedPipeServerStream CreateAndConnectPipe(string pipeName)
+        {
+            var pipe = CreatePipe(pipeName);
+            pipe.WaitForConnection();
 
-			return pipe;
-		}
+            return pipe;
+        }
 
-		public static NamedPipeServerStream CreatePipe(string pipeName)
-		{
-			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
-		}
+        public static NamedPipeServerStream CreatePipe(string pipeName)
+        {
+            return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message,
+                PipeOptions.Asynchronous);
+        }
 
-		public static NamedPipeServerStream CreateAndConnectPipe(string pipeName, int bufferSize, PipeSecurity security)
-		{
-			var pipe = CreatePipe(pipeName, bufferSize, security);
-			pipe.WaitForConnection();
+        public static NamedPipeServerStream CreateAndConnectPipe(string pipeName, int bufferSize, PipeSecurity security)
+        {
+            var pipe = CreatePipe(pipeName, bufferSize, security);
+            pipe.WaitForConnection();
 
-			return pipe;
-		}
+            return pipe;
+        }
 
-		public static NamedPipeServerStream CreatePipe(string pipeName, int bufferSize, PipeSecurity security)
-		{
-			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous, bufferSize, bufferSize, security);
-		}
-	}
+        public static NamedPipeServerStream CreatePipe(string pipeName, int bufferSize, PipeSecurity security)
+        {
+            return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message,
+                PipeOptions.Asynchronous, bufferSize, bufferSize, security);
+        }
+    }
 }

--- a/NamedPipeWrapper/PipeServerFactory.cs
+++ b/NamedPipeWrapper/PipeServerFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 
 namespace NamedPipeWrapper
 {
@@ -14,7 +14,7 @@ namespace NamedPipeWrapper
 
 		public static NamedPipeServerStream CreatePipe(string pipeName)
 		{
-			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.WriteThrough);
+			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
 		}
 
 		public static NamedPipeServerStream CreateAndConnectPipe(string pipeName, int bufferSize, PipeSecurity security)
@@ -27,7 +27,7 @@ namespace NamedPipeWrapper
 
 		public static NamedPipeServerStream CreatePipe(string pipeName, int bufferSize, PipeSecurity security)
 		{
-			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.WriteThrough, bufferSize, bufferSize, security);
+			return new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous, bufferSize, bufferSize, security);
 		}
 	}
 }

--- a/UnitTests/StringNamedPipeTests.cs
+++ b/UnitTests/StringNamedPipeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.IO.Pipes;
 using System.Text;
@@ -59,6 +59,7 @@ namespace UnitTests
         }
 
         #region Helpers
+
         private void StartServer()
         {
             _server = new StringNamedPipeServer(PipeName);
@@ -75,6 +76,9 @@ namespace UnitTests
             var pipeName = ClientReadMessage();
             _client.Close();
 
+            // Wait for data pipe connection to be created 
+            Thread.Sleep(1000);
+
             // Connect to data pipe
             _client = new NamedPipeClientStream(pipeName);
             _client.Connect();
@@ -85,12 +89,12 @@ namespace UnitTests
             const int bufferSize = 1024;
             var buffer = new byte[bufferSize];
             _client.Read(buffer, 0, bufferSize);
-            return Encoding.UTF8.GetString(buffer).TrimEnd('\0');
+            return Encoding.Unicode.GetString(buffer).TrimEnd('\0');
         }
 
         private void ClientSendMessage(string message)
         {
-            var messageBytes = Encoding.UTF8.GetBytes(message);
+            var messageBytes = Encoding.Unicode.GetBytes(message);
             _client.Write(messageBytes, 0, messageBytes.Length);
             _client.Flush();
         }
@@ -100,6 +104,7 @@ namespace UnitTests
             _serverMessageQueue.Enqueue(message);
             _serverReceivedMessageEvent.Set();
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
Changed the pipe transmission mode to `Message` and only allow `Asynchronous` clients for better compatibility with C++ clients.